### PR TITLE
Update the auth endpoints to use JWT token and Store the token in the…

### DIFF
--- a/Backend/config/db.js
+++ b/Backend/config/db.js
@@ -1,7 +1,6 @@
-
 const mongoose = require('mongoose');
 require('dotenv').config();
 
-const connection = mongoose.connect(process.env.mongoURI, { useNewUrlParser: true, useUnifiedTopology: true });
+const connection = mongoose.connect(process.env.mongoURI);
 
-module.exports={connection}
+module.exports = { connection };

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -11,10 +11,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "joi": "^17.12.3",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.1.3",
     "nodemon": "^3.0.3"
   }


### PR DESCRIPTION
I updated the login endpoint to generate a JWT token using the jwt.sign method with the username and a secret key. If token generation is successful, it sets the token in a cookie and sends the token in the response body.
I included  Error handling for cases where token generation fails, returning a 401 status code with an error message.
What i did here basically is i replaced the previous method of sending the username in the response body with sending the generated JWT token.
JWT tokens are commonly used for authentication and authorization in web applications, providing a secure way to validate user identity.